### PR TITLE
add abap keyword + dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,15 @@
     "engines": {
         "vscode": "^1.28.0"
     },
+	"keywords": [
+		"abap"
+	],    
     "categories": [
         "Snippets"
     ],
+	"extensionDependencies": [
+		"larshp.vscode-abap"
+	],    
     "contributes": {
         "snippets": [
             {


### PR DESCRIPTION
requires the vscode-abap dependency in order to be able to identify abap as language